### PR TITLE
Update docker compose, README and appsettings example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This application is largely inspired by: https://github.com/luontola/cqrs-hotel
 1. Create the `appsettings.json` files by copying the `appsettings.Example.json` files in 
     * `Infi.DojoEventSourcing.Api`
     * `Infi.DojoEventSourcing.ReadModelDbMigrator`
+    * `Infi.DojoEventSourcing.ReadModelRebuilder`
 2. We'll be working with [EventStore](https://eventstore.com/). You'll need an instance to write our events to. Choose one of the following options:
     * OR: Run `docker-compose up` from the root directory in this repository.
     * OR: Install EventStore manually by following the instructions [here](https://eventstore.com/docs/getting-started/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '2'
 services:
   eventstore:
     image: eventstore/eventstore
+    environment:
+      - EVENTSTORE_INSECURE=true
     restart: always
     volumes:
       - eventstore-data:/var/lib/eventstore

--- a/src/Infi.DojoEventSourcing.ReadModelRebuilder/appsettings.Example.json
+++ b/src/Infi.DojoEventSourcing.ReadModelRebuilder/appsettings.Example.json
@@ -5,6 +5,6 @@
     "ReconnectionDelayInSeconds": 30
   },
   "ApiReadModel": {
-    "ConnectionString": "Data Source=/home/bryan/Projects/DojoEventSourcing/readmodel.db;"
+    "ConnectionString": "Data Source=<PATH>;"
   }
 }


### PR DESCRIPTION
- Add insecure env var for new EventStoreDB version (reason: https://developers.eventstore.com/server/v20.10/security/configuration.html#running-without-security)
- Update appsetttings example and README to include ReadModelRebuilder project.